### PR TITLE
Archive Restore: errors on backend for multple items #335

### DIFF
--- a/src/main/resources/assets/js/ArchiveHelper.ts
+++ b/src/main/resources/assets/js/ArchiveHelper.ts
@@ -1,0 +1,33 @@
+import {ContentPath} from 'lib-contentstudio/app/content/ContentPath';
+
+interface ItemWithPath {
+    getPath(): ContentPath;
+}
+
+export abstract class ArchiveHelper {
+
+    public static filterTopMostItems(items: ItemWithPath[]): ItemWithPath[]  {
+        const result: ItemWithPath[] = [];
+
+        items.forEach((item: ItemWithPath) => {
+            const contains: boolean = result.some((itemToDelete: ItemWithPath, index: number) => {
+                if (item.getPath().isDescendantOf(itemToDelete.getPath())) {
+                    return true;
+                }
+
+                if (itemToDelete.getPath().isDescendantOf(item.getPath())) {
+                    result[index] = item;
+                    return true;
+                }
+
+                return false;
+            });
+
+            if (!contains) {
+                result.push(item);
+            }
+        });
+
+        return result;
+    }
+}

--- a/src/main/resources/assets/js/ArchiveHelper.ts
+++ b/src/main/resources/assets/js/ArchiveHelper.ts
@@ -9,14 +9,14 @@ export abstract class ArchiveHelper {
     public static filterTopMostItems(items: ItemWithPath[]): ItemWithPath[]  {
         const result: ItemWithPath[] = [];
 
-        items.forEach((item: ItemWithPath) => {
-            const contains: boolean = result.some((itemToDelete: ItemWithPath, index: number) => {
-                if (item.getPath().isDescendantOf(itemToDelete.getPath())) {
+        items.forEach((thisItem: ItemWithPath) => {
+            const contains: boolean = result.some((otherItem: ItemWithPath, index: number) => {
+                if (thisItem.getPath().isDescendantOf(otherItem.getPath())) {
                     return true;
                 }
 
-                if (itemToDelete.getPath().isDescendantOf(item.getPath())) {
-                    result[index] = item;
+                if (otherItem.getPath().isDescendantOf(thisItem.getPath())) {
+                    result[index] = thisItem;
                     return true;
                 }
 
@@ -24,7 +24,7 @@ export abstract class ArchiveHelper {
             });
 
             if (!contains) {
-                result.push(item);
+                result.push(thisItem);
             }
         });
 

--- a/src/main/resources/assets/js/ArchiveProgressDialog.ts
+++ b/src/main/resources/assets/js/ArchiveProgressDialog.ts
@@ -2,9 +2,11 @@ import {ArchiveDialog} from './ArchiveDialog';
 import {NotifyManager} from 'lib-admin-ui/notify/NotifyManager';
 import {ProgressBarManager} from 'lib-contentstudio/app/dialog/ProgressBarManager';
 import {TaskState} from 'lib-admin-ui/task/TaskState';
+import {ManagedActionExecutor} from 'lib-admin-ui/managedaction/ManagedActionExecutor';
 
 export abstract class ArchiveProgressDialog
-    extends ArchiveDialog {
+    extends ArchiveDialog
+    implements ManagedActionExecutor {
 
     progressManager: ProgressBarManager;
 
@@ -12,7 +14,7 @@ export abstract class ArchiveProgressDialog
         super.initElements();
 
         this.progressManager = new ProgressBarManager({
-            managingElement: <any>this,
+            managingElement: this,
             processingLabel: this.getProcessingLabelText()
         });
     }
@@ -43,4 +45,8 @@ export abstract class ArchiveProgressDialog
     protected abstract getSuccessTextForSingle(): string;
 
     protected abstract getFailText(): string;
+
+    isExecuting(): boolean {
+        return this.progressManager.isActive();
+    }
 }

--- a/src/main/resources/assets/js/ArchiveRestoreDialog.ts
+++ b/src/main/resources/assets/js/ArchiveRestoreDialog.ts
@@ -4,6 +4,7 @@ import {DefaultErrorHandler} from 'lib-admin-ui/DefaultErrorHandler';
 import {TaskId} from 'lib-admin-ui/task/TaskId';
 import {ArchiveProgressDialog} from './ArchiveProgressDialog';
 import {ArchiveViewItem} from './ArchiveViewItem';
+import {ArchiveHelper} from './ArchiveHelper';
 
 export class ArchiveRestoreDialog
     extends ArchiveProgressDialog {
@@ -52,28 +53,7 @@ export class ArchiveRestoreDialog
     }
 
     private getItemsToRestore(): string[] {
-        const itemsToDelete: ArchiveViewItem[] = [];
-
-        this.items.forEach((item: ArchiveViewItem) => {
-            const contains: boolean = itemsToDelete.some((itemToDelete: ArchiveViewItem, index: number) => {
-                if (item.getData().getPath().isDescendantOf(itemToDelete.getData().getPath())) {
-                    return true;
-                }
-
-                if (itemToDelete.getData().getPath().isDescendantOf(item.getData().getPath())) {
-                    itemsToDelete[index] = item;
-                    return true;
-                }
-
-                return false;
-            });
-
-            if (!contains) {
-                itemsToDelete.push(item);
-            }
-        });
-
-        return itemsToDelete.map((item) => item.getId());
+        return (<ArchiveViewItem[]>ArchiveHelper.filterTopMostItems(this.items)).map((item: ArchiveViewItem) => item.getId());
     }
 
     protected getConfirmValueDialogTitle(): string {

--- a/src/main/resources/assets/js/ArchiveTreeGrid.ts
+++ b/src/main/resources/assets/js/ArchiveTreeGrid.ts
@@ -17,6 +17,7 @@ import {ContentPath} from 'lib-contentstudio/app/content/ContentPath';
 import {ContentId} from 'lib-contentstudio/app/content/ContentId';
 import {NodeServerChangeType} from 'lib-admin-ui/event/NodeServerChange';
 import {ContentServerChangeItem} from 'lib-contentstudio/app/event/ContentServerChangeItem';
+import {ArchiveHelper} from './ArchiveHelper';
 
 export class ArchiveTreeGrid
     extends TreeGrid<ArchiveViewItem> {
@@ -73,28 +74,7 @@ export class ArchiveTreeGrid
     }
 
     private extractTopMostContentItems(event: ArchiveServerEvent): ContentServerChangeItem[] {
-        const itemsToDelete: ContentServerChangeItem[] = [];
-
-        event.getNodeChange().getChangeItems().forEach((eventItem: ContentServerChangeItem) => {
-            const contains: boolean = itemsToDelete.some((itemToDelete: ContentServerChangeItem, index: number) => {
-                if (eventItem.getPath().isDescendantOf(itemToDelete.getPath())) {
-                    return true;
-                }
-
-                if (itemToDelete.getPath().isDescendantOf(eventItem.getPath())) {
-                    itemsToDelete[index] = eventItem;
-                    return true;
-                }
-
-                return false;
-            });
-
-            if (!contains) {
-                itemsToDelete.push(eventItem);
-            }
-        });
-
-        return itemsToDelete;
+        return <ContentServerChangeItem[]>ArchiveHelper.filterTopMostItems(event.getNodeChange().getChangeItems());
     }
 
     refresh() {

--- a/src/main/resources/assets/js/ArchiveTreeGridHelper.ts
+++ b/src/main/resources/assets/js/ArchiveTreeGridHelper.ts
@@ -9,11 +9,6 @@ import {Viewer} from 'lib-admin-ui/ui/Viewer';
 import {ArchiveContentViewer} from './ArchiveContentViewer';
 import {i18n} from 'lib-admin-ui/util/Messages';
 import {SpanEl} from 'lib-admin-ui/dom/SpanEl';
-import {ContentPath} from 'lib-contentstudio/app/content/ContentPath';
-
-interface ItemWithPath {
-    getPath(): ContentPath;
-}
 
 export class ArchiveTreeGridHelper {
 

--- a/src/main/resources/assets/js/ArchiveTreeGridHelper.ts
+++ b/src/main/resources/assets/js/ArchiveTreeGridHelper.ts
@@ -9,6 +9,11 @@ import {Viewer} from 'lib-admin-ui/ui/Viewer';
 import {ArchiveContentViewer} from './ArchiveContentViewer';
 import {i18n} from 'lib-admin-ui/util/Messages';
 import {SpanEl} from 'lib-admin-ui/dom/SpanEl';
+import {ContentPath} from 'lib-contentstudio/app/content/ContentPath';
+
+interface ItemWithPath {
+    getPath(): ContentPath;
+}
 
 export class ArchiveTreeGridHelper {
 

--- a/src/main/resources/assets/js/ArchiveViewItem.ts
+++ b/src/main/resources/assets/js/ArchiveViewItem.ts
@@ -2,6 +2,7 @@ import {Equitable} from 'lib-admin-ui/Equitable';
 import {ObjectHelper} from 'lib-admin-ui/ObjectHelper';
 import {ViewItem} from 'lib-admin-ui/app/view/ViewItem';
 import {ContentSummaryAndCompareStatus} from 'lib-contentstudio/app/content/ContentSummaryAndCompareStatus';
+import { ContentPath } from 'lib-contentstudio/app/content/ContentPath';
 
 export abstract class ArchiveViewItem implements ViewItem {
 
@@ -51,6 +52,10 @@ export abstract class ArchiveViewItem implements ViewItem {
 
     getData(): ContentSummaryAndCompareStatus {
         return this.data;
+    }
+
+    getPath(): ContentPath {
+        return this.data?.getPath();
     }
 }
 


### PR DESCRIPTION
-Currently backend restore task processor throws warning in case some items were not restored. That message is also spawned when restoring items are from the same inheritance tree. That also shows some errors in console. Now we will filter restored items and remove child items if selected together with ancestors
-Added missing ManagedActionExecutor interface for archive progress dialogs