### PR TITLE
Content Wizard - Layers Content Tree Dialog is not updated after dele…

### DIFF
--- a/src/main/resources/assets/js/widgets/layers/LayersWidget.ts
+++ b/src/main/resources/assets/js/widgets/layers/LayersWidget.ts
@@ -39,7 +39,7 @@ export class LayersWidget
     }
 
     private renderLayers(): void {
-        const layersWidgetItemView: LayersWidgetItemView = new LayersWidgetItemView();
+        const layersWidgetItemView: LayersWidgetItemView = LayersWidgetItemView.get();
 
         this.fetchContent().then((content: ContentSummaryAndCompareStatus) => {
             void layersWidgetItemView.setContentAndUpdateView(content);

--- a/src/main/resources/assets/js/widgets/layers/LayersWidgetItemView.ts
+++ b/src/main/resources/assets/js/widgets/layers/LayersWidgetItemView.ts
@@ -14,8 +14,6 @@ import {Store} from 'lib-admin-ui/store/Store';
 import {ContentServerEventsHandler} from 'lib-contentstudio/app/event/ContentServerEventsHandler';
 import {ContentServerChangeItem} from 'lib-contentstudio/app/event/ContentServerChangeItem';
 
-export const LAYERS_WIDGET_ITEM_VIEW = 'LayersWidgetItemView';
-
 export class LayersWidgetItemView
     extends DivEl {
 
@@ -42,11 +40,11 @@ export class LayersWidgetItemView
     }
 
     static get(): LayersWidgetItemView {
-        let instance: LayersWidgetItemView = Store.instance().get(LAYERS_WIDGET_ITEM_VIEW);
+        let instance: LayersWidgetItemView = Store.instance().get(LayersWidgetItemView.name);
 
         if (instance == null) {
             instance = new LayersWidgetItemView();
-            Store.instance().set(LAYERS_WIDGET_ITEM_VIEW, instance);
+            Store.instance().set(LayersWidgetItemView.name, instance);
         }
 
         return instance;
@@ -88,11 +86,11 @@ export class LayersWidgetItemView
             LayersContentTreeDialog.get().setItems(this.layerContentItems).open();
         });
 
-        this.listenProjectEvents();
-        this.listenContentEvents();
+        this.initProjectEventListeners();
+        this.initContentEventListeners();
     }
 
-    private listenProjectEvents(): void {
+    private initProjectEventListeners(): void {
         const projectUpdateHandler: () => void = () => {
             if (this.isVisible()) {
                 this.reload().catch(DefaultErrorHandler.handle);
@@ -104,7 +102,7 @@ export class LayersWidgetItemView
         ProjectDeletedEvent.on(projectUpdateHandler);
     }
 
-    private listenContentEvents(): void {
+    private initContentEventListeners(): void {
         const serverEventsHandler: ContentServerEventsHandler = ContentServerEventsHandler.getInstance();
 
         const contentDeletedHandler: (items: ContentServerChangeItem[]) => void = (items: ContentServerChangeItem[]) => {

--- a/src/main/resources/assets/js/widgets/layers/ShowAllContentLayersButton.ts
+++ b/src/main/resources/assets/js/widgets/layers/ShowAllContentLayersButton.ts
@@ -2,22 +2,15 @@ import {ActionButton} from 'lib-admin-ui/ui/button/ActionButton';
 import {Action} from 'lib-admin-ui/ui/Action';
 import {i18n} from 'lib-admin-ui/util/Messages';
 import * as Q from 'q';
-import {LayersContentTreeDialog} from './dialog/LayersContentTreeDialog';
 import {LayerContent} from './LayerContent';
 
 export class ShowAllContentLayersButton extends ActionButton {
 
-    private items: LayerContent[];
-
     constructor() {
         super(new Action(i18n('widget.layers.showall', 0)));
-
-        this.initListeners();
     }
 
-    setItems(items: LayerContent[]): void {
-        this.items = items;
-
+    updateLabelAndVisibility(items: LayerContent[]): void {
         const total: number = items.filter((layerContent: LayerContent) => layerContent.hasItem()).length;
         this.setLabel(i18n('widget.layers.showall', total));
         this.setVisible(items.length > 1);
@@ -28,12 +21,6 @@ export class ShowAllContentLayersButton extends ActionButton {
             this.addClass('show-all-button');
 
             return rendered;
-        });
-    }
-
-    private initListeners(): void {
-        this.getAction().onExecuted(() => {
-            LayersContentTreeDialog.get().setItems(this.items).open();
         });
     }
 }

--- a/src/main/resources/assets/js/widgets/layers/dialog/LayersContentTreeDialog.ts
+++ b/src/main/resources/assets/js/widgets/layers/dialog/LayersContentTreeDialog.ts
@@ -5,10 +5,11 @@ import {ProjectContext} from 'lib-contentstudio/app/project/ProjectContext';
 import {ContentSummaryAndCompareStatus} from 'lib-contentstudio/app/content/ContentSummaryAndCompareStatus';
 import {LayerContent} from '../LayerContent';
 import {LayersContentTreeList} from '../LayersContentTreeList';
+import {Store} from 'lib-admin-ui/store/Store';
+
+export const LAYERS_CONTENT_TREE_DIALOG_KEY = 'LayersContentTreeDialog';
 
 export class LayersContentTreeDialog extends ModalDialog {
-
-    private static INSTANCE: LayersContentTreeDialog;
 
     private layersContentTreeList: LayersContentTreeList;
 
@@ -16,16 +17,19 @@ export class LayersContentTreeDialog extends ModalDialog {
 
     private constructor() {
         super({
-            class: 'layers-content-tree-dialog',
+            class: 'layers-content-tree-dialog'
         });
     }
 
     static get(): LayersContentTreeDialog {
-        if (!LayersContentTreeDialog.INSTANCE) {
-            LayersContentTreeDialog.INSTANCE = new LayersContentTreeDialog();
+        let instance: LayersContentTreeDialog = Store.instance().get(LAYERS_CONTENT_TREE_DIALOG_KEY);
+
+        if (instance == null) {
+            instance = new LayersContentTreeDialog();
+            Store.instance().set(LAYERS_CONTENT_TREE_DIALOG_KEY, instance);
         }
 
-        return LayersContentTreeDialog.INSTANCE;
+        return instance;
     }
 
     setItems(items: LayerContent[]): LayersContentTreeDialog {

--- a/src/main/resources/assets/js/widgets/layers/dialog/LayersContentTreeDialog.ts
+++ b/src/main/resources/assets/js/widgets/layers/dialog/LayersContentTreeDialog.ts
@@ -16,9 +16,7 @@ export class LayersContentTreeDialog extends ModalDialog {
     private subTitle: H6El;
 
     private constructor() {
-        super({
-            class: 'layers-content-tree-dialog'
-        });
+        super({class: 'layers-content-tree-dialog'});
     }
 
     static get(): LayersContentTreeDialog {

--- a/src/main/resources/assets/js/widgets/layers/dialog/LayersContentTreeDialog.ts
+++ b/src/main/resources/assets/js/widgets/layers/dialog/LayersContentTreeDialog.ts
@@ -7,8 +7,6 @@ import {LayerContent} from '../LayerContent';
 import {LayersContentTreeList} from '../LayersContentTreeList';
 import {Store} from 'lib-admin-ui/store/Store';
 
-export const LAYERS_CONTENT_TREE_DIALOG_KEY = 'LayersContentTreeDialog';
-
 export class LayersContentTreeDialog extends ModalDialog {
 
     private layersContentTreeList: LayersContentTreeList;
@@ -20,11 +18,11 @@ export class LayersContentTreeDialog extends ModalDialog {
     }
 
     static get(): LayersContentTreeDialog {
-        let instance: LayersContentTreeDialog = Store.instance().get(LAYERS_CONTENT_TREE_DIALOG_KEY);
+        let instance: LayersContentTreeDialog = Store.instance().get(LayersContentTreeDialog.name);
 
         if (instance == null) {
             instance = new LayersContentTreeDialog();
-            Store.instance().set(LAYERS_CONTENT_TREE_DIALOG_KEY, instance);
+            Store.instance().set(LayersContentTreeDialog.name, instance);
         }
 
         return instance;


### PR DESCRIPTION
…ting a layer #381

-Added tracking of project events for layers widget.
However need to notice that widget is being rendered from scratch each time new item is selected in grid in a browse panel or when layers widget is selected, thus have to stop listening project events for stale widget dom objects