### PR TITLE
Group dependabot npm updates for @enonic-types/* and @wdio/*

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
       - "alansemenov"
     reviewers:
       - "alansemenov"
+    groups:
+      enonic-types:
+        patterns:
+          - "@enonic-types/*"
   - package-ecosystem: "npm"
     directory: "/testing"
     schedule:
@@ -27,6 +31,11 @@ updates:
       - "alansemenov"
     reviewers:
       - "alansemenov"
+    groups:
+      wdio:
+        patterns:
+          - "@wdio/*"
+          - "webdriverio"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Avoids spawning a separate PR per package for these scoped families (e.g. @wdio/cli, @wdio/concise-reporter, @wdio/allure-reporter all bumping together).