### PR TITLE
No progress bar in the Restore dialog

### DIFF
--- a/src/main/resources/assets/js/v6/features/shared/dialogs/archive/ArchiveDeleteDialog.tsx
+++ b/src/main/resources/assets/js/v6/features/shared/dialogs/archive/ArchiveDeleteDialog.tsx
@@ -14,8 +14,8 @@ import {ArchiveDialogShell} from './ArchiveDialogShell';
 const ARCHIVE_DELETE_DIALOG_NAME = 'ArchiveDeleteDialog';
 
 export const ArchiveDeleteDialog = (): ReactElement => {
-    const {open, items, descendants, loading, submitting, taskId} = useStore($archiveDeleteDialog, {
-        keys: ['open', 'items', 'descendants', 'loading', 'submitting', 'taskId'],
+    const {open, items, descendants, loading, failed, submitting, taskId} = useStore($archiveDeleteDialog, {
+        keys: ['open', 'items', 'descendants', 'loading', 'failed', 'submitting', 'taskId'],
     });
     const total = useStore($archiveDeleteTotal);
     const title = useI18n('dialog.delete.archive.title');
@@ -38,6 +38,9 @@ export const ArchiveDeleteDialog = (): ReactElement => {
             total={total}
             taskId={taskId}
             ready={ready}
+            loading={loading}
+            failed={failed}
+            progressDescriptionKey="dialog.deleting"
             onCancel={cancelArchiveDeleteDialog}
             onExecute={executeArchiveDeleteDialog}
             onTaskComplete={handleArchiveDeleteTaskComplete}

--- a/src/main/resources/assets/js/v6/features/shared/dialogs/archive/ArchiveDialogShell.tsx
+++ b/src/main/resources/assets/js/v6/features/shared/dialogs/archive/ArchiveDialogShell.tsx
@@ -1,9 +1,12 @@
 import type {TaskId} from '@enonic/lib-admin-ui/task/TaskId';
 import type {ContentSummary} from '@enonic/lib-contentstudio/app/content/ContentSummary';
+import {useAnimatedEllipsis} from '@enonic/lib-contentstudio/v6/features/hooks/useAnimatedEllipsis';
+import {useI18n} from '@enonic/lib-contentstudio/v6/features/hooks/useI18n';
 import {useTaskProgress} from '@enonic/lib-contentstudio/v6/features/hooks/useTaskProgress';
 import {ContentLabel} from '@enonic/lib-contentstudio/v6/features/shared/content/ContentLabel';
 import {DialogPresetGatedConfirmContent} from '@enonic/lib-contentstudio/v6/features/shared/dialogs/DialogPreset';
 import {ProgressDialogContent} from '@enonic/lib-contentstudio/v6/features/shared/dialogs/ProgressDialogContent';
+import {InboundStatusBar} from '@enonic/lib-contentstudio/v6/features/shared/dialogs/status-bar/InboundStatusBar';
 import {Button, Dialog, ListItem, Separator} from '@enonic/ui';
 import {type ReactElement, useEffect, useState} from 'react';
 import {ArchiveContentViewItem} from '../../../../../ArchiveContentViewItem';
@@ -17,6 +20,9 @@ export type ArchiveDialogShellProps = {
     total: number;
     taskId: TaskId | undefined;
     ready: boolean;
+    loading?: boolean;
+    failed?: boolean;
+    progressDescriptionKey?: string;
     onCancel: () => void;
     onExecute: () => Promise<boolean>;
     onTaskComplete: (success: boolean, message?: string) => void;
@@ -30,6 +36,20 @@ export type ArchiveDialogShellProps = {
     'data-component': string;
 };
 
+const noop = (): void => undefined;
+
+const getProgressDescription = (
+    phaseAware: boolean,
+    resolving: boolean,
+    resolvingDescription: string,
+    progressDescription: string,
+): string | undefined => {
+    if (!phaseAware) {
+        return undefined;
+    }
+    return resolving ? resolvingDescription : progressDescription;
+};
+
 export const ArchiveDialogShell = ({
     open,
     items,
@@ -37,6 +57,9 @@ export const ArchiveDialogShell = ({
     total,
     taskId,
     ready,
+    loading = false,
+    failed = false,
+    progressDescriptionKey,
     onCancel,
     onExecute,
     onTaskComplete,
@@ -50,11 +73,16 @@ export const ArchiveDialogShell = ({
     'data-component': dataComponent,
 }: ArchiveDialogShellProps): ReactElement => {
     const [view, setView] = useState<View>('main');
-    const {progress} = useTaskProgress(taskId, {
+    const {progress, phase, phaseTotal} = useTaskProgress(taskId, {
         onComplete: (resultState, message) => {
             onTaskComplete(resultState === 'SUCCESS', message);
         },
     });
+
+    const phaseAware = progressDescriptionKey != null;
+    const resolving = phaseAware && phase == null;
+    const resolvingDescription = useAnimatedEllipsis(useI18n('dialog.statusBar.loading'), view === 'progress' && resolving);
+    const progressDescription = useI18n(progressDescriptionKey ?? 'dialog.statusBar.loading', phaseTotal ?? total);
 
     useEffect(() => {
         if (!open) {
@@ -101,6 +129,11 @@ export const ArchiveDialogShell = ({
                         className="w-full h-full gap-10 sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220"
                     >
                         <Dialog.DefaultHeader title={title} description={description} withClose />
+                        <InboundStatusBar
+                            loading={loading}
+                            failed={failed}
+                            errors={{inbound: {count: 0, onIgnore: noop}}}
+                        />
                         <Dialog.Body className="flex flex-col gap-y-10">
                             <ul className="flex flex-col gap-y-2.5">
                                 {items.map((item) => (
@@ -154,7 +187,8 @@ export const ArchiveDialogShell = ({
                 {view === 'progress' && (
                     <ProgressDialogContent
                         title={progressTitle}
-                        progress={progress}
+                        description={getProgressDescription(phaseAware, resolving, resolvingDescription, progressDescription)}
+                        progress={resolving ? undefined : progress}
                         className="w-full h-full gap-10 sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220"
                     />
                 )}

--- a/src/main/resources/assets/js/v6/features/shared/dialogs/archive/ArchiveRestoreDialog.tsx
+++ b/src/main/resources/assets/js/v6/features/shared/dialogs/archive/ArchiveRestoreDialog.tsx
@@ -14,8 +14,8 @@ import {ArchiveDialogShell} from './ArchiveDialogShell';
 const ARCHIVE_RESTORE_DIALOG_NAME = 'ArchiveRestoreDialog';
 
 export const ArchiveRestoreDialog = (): ReactElement => {
-    const {open, items, descendants, loading, submitting, taskId} = useStore($archiveRestoreDialog, {
-        keys: ['open', 'items', 'descendants', 'loading', 'submitting', 'taskId'],
+    const {open, items, descendants, loading, failed, submitting, taskId} = useStore($archiveRestoreDialog, {
+        keys: ['open', 'items', 'descendants', 'loading', 'failed', 'submitting', 'taskId'],
     });
     const total = useStore($archiveRestoreTotal);
     const title = useI18n('dialog.restore.archive.title');
@@ -38,6 +38,9 @@ export const ArchiveRestoreDialog = (): ReactElement => {
             total={total}
             taskId={taskId}
             ready={ready}
+            loading={loading}
+            failed={failed}
+            progressDescriptionKey="dialog.restoring"
             onCancel={cancelArchiveRestoreDialog}
             onExecute={executeArchiveRestoreDialog}
             onTaskComplete={handleArchiveRestoreTaskComplete}


### PR DESCRIPTION
Needs https://github.com/enonic/app-contentstudio/pull/10820

Added progress feedback to the Restore from Archive dialog, matching the behavior of the Publish and Delete dialogs in Content Studio.

  - The main view shows a "Resolving items..." status bar with a spinner while dependant items are being loaded, and an error entry if loading fails.
  - After clicking Restore, the progress view shows "Resolving items..." with an animated ellipsis and no progress bar until the task reports its first progress, then switches to "Restoring N item(s)..." with a gradually filling bar.
  - `ArchiveDialogShell` accepts new optional `loading`, `failed` and `progressDescriptionKey` props; only the Restore dialog opts in, so the Delete from Archive dialog is unaffected.

Requires the corresponding Content Studio changes: the restore task now resolves descendants of archived content for a correct progress total and reports a `restore` phase marker at the first progress callback.

  <sub>*Drafted with AI assistance*</sub>