### PR TITLE
Widgets are loaded only once

### DIFF
--- a/src/main/resources/admin/extensions/archive/archive.js
+++ b/src/main/resources/admin/extensions/archive/archive.js
@@ -10,10 +10,10 @@ function handleGet(req) {
     const params = {
         bootstrapAssetsUri: portal.assetUrl({
             path: 'js/archive-bootstrap.js'
-        }),
+        }) + '?v=' + Date.now(),
         assetsUri: portal.assetUrl({
             path: 'js/archive.js'
-        }),
+        }) + '?v=' + Date.now(),
         stylesUri: portal.assetUrl({
             path: 'styles/main.css'
         }),

--- a/src/main/resources/admin/extensions/layers/layers.js
+++ b/src/main/resources/admin/extensions/layers/layers.js
@@ -34,7 +34,7 @@ function renderWidgetView(req) {
         }),
         jsUri: portal.assetUrl({
             path: 'js/extension/layers.js'
-        }),
+        }) + '?v=' + Date.now(),
         configScriptId: 'extension-layers-config-json',
         configAsJson: JSON.stringify(configLib.getConfig(req.locales), null, 4).replace(/<(\/?script|!--)/gi, "\\u003C$1")
     };

--- a/src/main/resources/admin/extensions/publish-report/publish-report.js
+++ b/src/main/resources/admin/extensions/publish-report/publish-report.js
@@ -37,7 +37,7 @@ const getBaseParams = (locales) => {
         }),
         jsUri: portal.assetUrl({
             path: 'js/extension/publish-report.js'
-        }),
+        }) + '?v=' + Date.now(),
         configScriptId: 'extension-pr-config-json',
         configAsJson: JSON.stringify(configLib.getConfig(locales), null, 4).replace(/<(\/?script|!--)/gi, "\\u003C$1"),
         isNoPublishMode: false,

--- a/src/main/resources/admin/extensions/variants/variants.js
+++ b/src/main/resources/admin/extensions/variants/variants.js
@@ -33,7 +33,7 @@ function renderWidgetView(req) {
         }),
         jsUri: portal.assetUrl({
             path: 'js/extension/variants.js'
-        }),
+        }) + '?v=' + Date.now(),
         configScriptId: 'extension-variants-config-json',
         configAsJson: JSON.stringify(configLib.getConfig(req.locales), null, 4).replace(/<(\/?script|!--)/gi, "\\u003C$1")
     };


### PR DESCRIPTION
All CS+ scripts are of type "module" and don't get reloaded as long as asset url remains the same. This was broke after removal of cache-bust (cb) parameter from shadow script loader in lib-admin-ui. Applying the fix directly here.