### PR TITLE
Sync Content Studio Plus with recent Content Studio changes #1830 #1832

### DIFF
--- a/src/main/resources/assets/js/archive.ts
+++ b/src/main/resources/assets/js/archive.ts
@@ -3,10 +3,14 @@ import type {Element} from '@enonic/lib-admin-ui/dom/Element';
 import {initConfig} from '@enonic/lib-contentstudio/v6/shared/config/config.store';
 import {whenProjectInitialized} from '@enonic/lib-contentstudio/v6/entities/project/activeProject.store';
 import {initProjects} from '@enonic/lib-contentstudio/v6/entities/project/projects.store';
-import {ArchiveAppContainer} from './ArchiveAppContainer';
 import {getModuleScript, getRequiredAttribute} from './util/ModuleScriptHelper';
 
-const injectApp = (widgetElem: Element): void => {
+// ! Import the app container lazily so v6 config is initialized (initConfig below)
+// ! before modules such as liveViewWidgets.store run their import-time widget fetch.
+// ! A static import evaluates that fetch against an empty extensionApiUrl, leaving
+// ! the preview widget selector empty. Mirrors app-contentstudio main.ts.
+const injectApp = async (widgetElem: Element): Promise<void> => {
+    const {ArchiveAppContainer} = await import('./ArchiveAppContainer');
     const archiveAppContainer = new ArchiveAppContainer();
     widgetElem.appendChild(archiveAppContainer);
 };
@@ -22,7 +26,7 @@ void (() => {
 
     const renderListener = (): void => {
         whenProjectInitialized(() => {
-            injectApp(widgetEl);
+            void injectApp(widgetEl);
         });
         body.unRendered(renderListener);
     };

--- a/src/main/resources/assets/js/v6/features/api/archive-attachments.ts
+++ b/src/main/resources/assets/js/v6/features/api/archive-attachments.ts
@@ -1,9 +1,10 @@
 import {computed, task} from 'nanostores';
+import type {AttachmentJson} from '@enonic/lib-contentstudio/app/attachment/AttachmentJson';
 import {Attachments} from '@enonic/lib-contentstudio/app/attachment/Attachments';
 import {ContentId} from '@enonic/lib-contentstudio/app/content/ContentId';
 import {ContentPath} from '@enonic/lib-contentstudio/app/content/ContentPath';
-import {GetContentAttachmentsRequest} from '@enonic/lib-contentstudio/app/resource/GetContentAttachmentsRequest';
 import {$projects} from '@enonic/lib-contentstudio/v6/entities/project/projects.store';
+import {requestJson} from '@enonic/lib-contentstudio/v6/shared/api/client';
 import {getCmsRestUri} from '@enonic/lib-contentstudio/v6/shared/lib/url/cms';
 import {$archiveContextContent} from '../store/archive-selection';
 
@@ -12,9 +13,14 @@ function getArchiveCmsPath(endpoint: string): string {
     return `cms/${project}/${ContentPath.ARCHIVE_ROOT}/content/${endpoint}`;
 }
 
-export async function loadArchiveAttachments(contentId: ContentId): Promise<Attachments | null> {
-    const request = new GetContentAttachmentsRequest(contentId).setContentRootPath(ContentPath.ARCHIVE_ROOT);
-    return request.sendAndParse();
+export function loadArchiveAttachments(contentId: ContentId): Promise<Attachments | null> {
+    const url = `${getCmsRestUri(getArchiveCmsPath('getAttachments'))}?id=${encodeURIComponent(contentId.toString())}`;
+    return requestJson<AttachmentJson[]>(url).match(
+        (json) => (json.length > 0 ? Attachments.create().fromJson(json).build() : null),
+        (error) => {
+            throw error;
+        },
+    );
 }
 
 export function getArchiveAttachmentUrl(contentId: ContentId, attachmentName: string): string {

--- a/src/main/resources/assets/js/v6/features/api/publish-report.ts
+++ b/src/main/resources/assets/js/v6/features/api/publish-report.ts
@@ -1,12 +1,9 @@
 import type {ContentVersion} from '@enonic/lib-contentstudio/app/ContentVersion';
 import {ContentId} from '@enonic/lib-contentstudio/app/content/ContentId';
 import type {ContentJson} from '@enonic/lib-contentstudio/app/content/ContentJson';
-import {GetContentSummaryByIdRequest}
-    from '@enonic/lib-contentstudio/app/resource/GetContentSummaryByIdRequest';
-import {GetContentVersionRequest}
-    from '@enonic/lib-contentstudio/app/resource/GetContentVersionRequest';
-import {GetContentVersionsRequest}
-    from '@enonic/lib-contentstudio/app/resource/GetContentVersionsRequest';
+import {resolveContentSummaries} from '@enonic/lib-contentstudio/v6/entities/content/api/content.api';
+import {fetchContentVersions, fetchVersion}
+    from '@enonic/lib-contentstudio/v6/entities/content/api/versions.api';
 import {ArchiveContentFetcher} from '../../../ArchiveContentFetcher';
 
 export type PublishReportData = {
@@ -25,8 +22,24 @@ export async function fetchPublishReportData(
     const [content, versionsResult] = await Promise.all([
         isArchived
             ? new ArchiveContentFetcher().fetch(cId)
-            : new GetContentSummaryByIdRequest(cId).sendAndParse(),
-        new GetContentVersionsRequest(cId).sendAndParse(),
+            : resolveContentSummaries([cId]).match(
+                (summaries) => {
+                    const summary = summaries[0];
+                    if (summary == null) {
+                        throw new Error(`Content not found: ${contentId}`);
+                    }
+                    return summary;
+                },
+                (error) => {
+                    throw error;
+                },
+            ),
+        fetchContentVersions({contentId: cId}).match(
+            (result) => result,
+            (error) => {
+                throw error;
+            },
+        ),
     ]);
 
     return {
@@ -41,18 +54,12 @@ export function fetchVersionContent(contentId: ContentId, versionId: string): Pr
         return cached;
     }
 
-    const promise = Promise.resolve(
-        new GetContentVersionRequest(contentId)
-            .setVersion(versionId)
-            .sendRequest()
-            .then(stripContentMetadata),
+    const promise = fetchVersion(contentId.toString(), versionId).match(
+        (content) => content,
+        (error) => {
+            throw error;
+        },
     );
     versionContentCache.set(versionId, promise);
     return promise;
-}
-
-function stripContentMetadata(content: ContentJson): ContentJson {
-    const cleaned = {...content};
-    delete cleaned.hasChildren;
-    return cleaned;
 }

--- a/src/main/resources/assets/js/v6/features/views/context/widget/details/ArchiveDetailsWidget.tsx
+++ b/src/main/resources/assets/js/v6/features/views/context/widget/details/ArchiveDetailsWidget.tsx
@@ -7,7 +7,7 @@ import type {ExtensionItemViewType}
     from '@enonic/lib-contentstudio/app/view/context/ExtensionItemView';
 import {LegacyElement} from '@enonic/lib-contentstudio/v6/shared/ui/LegacyElement';
 import {$activeWidgetId, $isContextOpen} from '@enonic/lib-contentstudio/v6/widgets/context-panel/model/contextWidgets.store';
-import {DETAILS_WIDGET_KEY} from '@enonic/lib-contentstudio/v6/shared/lib/widget/details';
+import {getDetailsWidgetKey} from '@enonic/lib-contentstudio/v6/shared/lib/widget/details';
 import {$archiveContextContent} from '../../../../store/archive-selection';
 import {ArchiveDetailsWidgetAttachmentsSection} from './ArchiveDetailsWidgetAttachmentsSection';
 import {ArchiveDetailsWidgetContentSection} from './ArchiveDetailsWidgetContentSection';
@@ -18,7 +18,7 @@ const ARCHIVE_DETAILS_WIDGET_NAME = 'ArchiveDetailsWidget';
 export const ArchiveDetailsWidget = (): ReactElement | null => {
     const isContextOpen = useStore($isContextOpen);
     const activeWidget = useStore($activeWidgetId);
-    const isActiveWidget = activeWidget === DETAILS_WIDGET_KEY;
+    const isActiveWidget = activeWidget === getDetailsWidgetKey();
     const content = useStore($archiveContextContent);
 
     if (!isContextOpen || !isActiveWidget || !content) return null;

--- a/src/main/resources/assets/js/v6/features/views/context/widget/versions/ArchiveVersionsWidget.tsx
+++ b/src/main/resources/assets/js/v6/features/views/context/widget/versions/ArchiveVersionsWidget.tsx
@@ -8,10 +8,10 @@ import {fetchVersion} from '@enonic/lib-contentstudio/v6/entities/content/api/ve
 import {LegacyElement} from '@enonic/lib-contentstudio/v6/shared/ui/LegacyElement';
 import {$activeWidgetId, $isContextOpen}
     from '@enonic/lib-contentstudio/v6/widgets/context-panel/model/contextWidgets.store';
-import {VERSIONS_WIDGET_KEY}
+import {getVersionsWidgetKey}
     from '@enonic/lib-contentstudio/v6/shared/lib/widget/versions/versions';
 import {loadContentVersions}
-    from '@enonic/lib-contentstudio/v6/shared/lib/widget/versions/versionsLoader';
+    from '@enonic/lib-contentstudio/v6/entities/content/version';
 import type {VersionsConfig}
     from '@enonic/lib-contentstudio/v6/widgets/context-panel/widget/versions/config/VersionsConfig';
 import {VersionsConfigProvider}
@@ -39,7 +39,7 @@ const createArchiveVersionsConfig = (): VersionsConfig => ({
 export const ArchiveVersionsWidget = (): ReactElement | null => {
     const isContextOpen = useStore($isContextOpen);
     const activeWidget = useStore($activeWidgetId);
-    const isActiveWidget = activeWidget === VERSIONS_WIDGET_KEY;
+    const isActiveWidget = activeWidget === getVersionsWidgetKey();
     const content = useStore($archiveContextContent);
     const config = useMemo(() => createArchiveVersionsConfig(), []);
 


### PR DESCRIPTION
Recent Content Studio changes broke Content Studio Plus in two ways; this PR addresses both.

**1. Build break — v6 fetch + Result client migration (#1830).** CS removed several request classes and renamed the context-widget key constants that Plus compiles from `lib-contentstudio` source at build time, so Vite failed with `Could not load .../GetContentVersionsRequest`. Migrated the affected v6 code to the new v6 APIs (v6 variants over legacy lib-contentstudio requests; lib-admin-ui requests left alone):
- `publish-report.ts`: `GetContentVersionsRequest` → `fetchContentVersions`, `GetContentVersionRequest` → `fetchVersion`, `GetContentSummaryByIdRequest` → `resolveContentSummaries`.
- `archive-attachments.ts`: `GetContentAttachmentsRequest` → a v6 `requestJson` call scoped to the archive content root (`ContentPath.ARCHIVE_ROOT`), preserving the archive-scoped endpoint.
- `ArchiveVersionsWidget.tsx`: moved `loadContentVersions` import to `v6/entities/content/version`; `VERSIONS_WIDGET_KEY` → `getVersionsWidgetKey()`.
- `ArchiveDetailsWidget.tsx`: `DETAILS_WIDGET_KEY` → `getDetailsWidgetKey()`.

**2. Archive preview widget selector regression (#1832).** After CS moved the preview toolbar to a v6 component, the archive item preview's "Open widget selector" dropdown stopped rendering (selenium `archive.image` / `archive.item.preview.for.text.content` failed). Root cause: `archive.ts` statically imported `ArchiveAppContainer`, whose graph eagerly evaluates `liveViewWidgets.store` (`void loadWidgets()` → `fetchExtensions`) at import time, before the bootstrap IIFE calls `initConfig()` — so the fetch used an empty `extensionApiUrl` and `$activeWidget` stayed undefined. Fixed by loading `ArchiveAppContainer` via a dynamic `import()` after `initConfig()`, mirroring `app-contentstudio` `main.ts`.

Note: `fetchVersion` strips more version metadata than the previous local helper (which only removed `hasChildren`), so the publish-report diff now matches Content Studio's own version comparison.

Closes #1830
Closes #1832

<sub>*Drafted with AI assistance*</sub>