### PR TITLE
GraalJS Compatibility #1869

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,12 @@ dependencies {
 
     devResources "com.enonic.lib:lib-admin-ui:${libAdminUiVersion}"
     devResources "com.enonic.lib:lib-contentstudio:${libContentStudioVersion}"
+
+    testImplementation libs.junit.jupiter
+    testImplementation libs.mockito.core
+    testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly libs.graalvm.js
 }
 
 repositories {
@@ -71,6 +77,22 @@ repositories {
     mavenCentral()
     xp.enonicRepo( 'dev' )
 }
+
+test {
+    useJUnitPlatform()
+}
+
+def testGraalJs = tasks.register( 'testGraalJs', Test ) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs
 
 tasks.register( 'checkTypes', PnpmTask ) {
     dependsOn tasks.named( 'pnpmInstall' )

--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,14 @@ tasks.register( 'pnpmBuild', PnpmTask ) {
     outputs.dir "${buildDir}/resources/main"
 }
 
+tasks.named( 'compileTestJava' ).configure {
+    mustRunAfter tasks.named( 'pnpmBuild' )
+}
+
+tasks.withType( Test ).configureEach {
+    mustRunAfter tasks.named( 'pnpmBuild' )
+}
+
 tasks.named( 'processResources' ).configure {
     // Don't need source files
     exclude 'assets/js/**'

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,6 @@ dependencies {
     testImplementation libs.mockito.core
     testImplementation "com.enonic.xp:testing:${xpVersion}"
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testRuntimeOnly libs.graalvm.js
 }
 
 repositories {
@@ -82,17 +81,9 @@ test {
     useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register( 'testGraalJs', Test ) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs
 
 tasks.register( 'checkTypes', PnpmTask ) {
     dependsOn tasks.named( 'pnpmInstall' )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 enonicDefaults = "2.1.7"
-xpApp = "4.1.0"
+xpApp = "4.2.0"
 nodeGradle = "7.1.0"
 
 # App
@@ -11,7 +11,6 @@ libLicense = "4.0.0"
 # Test
 junit = "6.1.2"
 mockito = "5.23.0"
-graalvm = "25.0.3"
 
 [libraries]
 
@@ -22,7 +21,6 @@ lib-license = { module = "com.enonic.lib:lib-license", version.ref = "libLicense
 # Test
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
-graalvm-js = { module = "org.graalvm.polyglot:js", version.ref = "graalvm" }
 
 [plugins]
 enonic-defaults = { id = "com.enonic.defaults", version.ref = "enonicDefaults" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,11 +8,21 @@ nodeGradle = "7.1.0"
 libMustache = "3.0.0"
 libLicense = "4.0.0"
 
+# Test
+junit = "6.1.2"
+mockito = "5.23.0"
+graalvm = "25.0.3"
+
 [libraries]
 
 # App
 lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "libMustache" }
 lib-license = { module = "com.enonic.lib:lib-license", version.ref = "libLicense" }
+
+# Test
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+graalvm-js = { module = "org.graalvm.polyglot:js", version.ref = "graalvm" }
 
 [plugins]
 enonic-defaults = { id = "com.enonic.defaults", version.ref = "enonicDefaults" }

--- a/src/main/resources/apis/layers/layers.js
+++ b/src/main/resources/apis/layers/layers.js
@@ -133,7 +133,7 @@ const getContentCompareStatus = (contentId, projectId) => {
         },
         () => {
             const bean = __.newBean('com.enonic.xp.app.contentstudio.plus.widgets.layers.CompareStatusHandler');
-            bean.contentId = __.nullOrValue(contentId);
+            bean.setContentId(__.nullOrValue(contentId));
             return __.toNativeObject(bean.getCompareStatus());
         }
     );

--- a/src/test/java/com/enonic/xp/app/contentstudio/plus/widgets/layers/LayersApiTest.java
+++ b/src/test/java/com/enonic/xp/app/contentstudio/plus/widgets/layers/LayersApiTest.java
@@ -1,0 +1,42 @@
+package com.enonic.xp.app.contentstudio.plus.widgets.layers;
+
+import com.enonic.xp.content.CompareContentResult;
+import com.enonic.xp.content.CompareContentResults;
+import com.enonic.xp.content.CompareContentsParams;
+import com.enonic.xp.content.CompareStatus;
+import com.enonic.xp.content.ContentId;
+import com.enonic.xp.content.GetPublishStatusResult;
+import com.enonic.xp.content.GetPublishStatusesParams;
+import com.enonic.xp.content.GetPublishStatusesResult;
+import com.enonic.xp.content.PublishStatus;
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class LayersApiTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    protected void initialize()
+        throws Exception
+    {
+        super.initialize();
+
+        final ContentId contentId = ContentId.from( "abc" );
+
+        final CompareContentResults compareResults =
+            CompareContentResults.create().add( new CompareContentResult( CompareStatus.NEW, contentId ) ).build();
+        when( this.contentService.compare( any( CompareContentsParams.class ) ) ).thenReturn( compareResults );
+
+        final GetPublishStatusesResult publishStatuses =
+            GetPublishStatusesResult.create().add( new GetPublishStatusResult( contentId, PublishStatus.ONLINE ) ).build();
+        when( this.contentService.getPublishStatuses( any( GetPublishStatusesParams.class ) ) ).thenReturn( publishStatuses );
+    }
+
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/test/layers-test.js";
+    }
+}

--- a/src/test/resources/test/layers-test.js
+++ b/src/test/resources/test/layers-test.js
@@ -1,0 +1,58 @@
+var assert = require('/lib/xp/testing');
+
+assert.mock('/lib/xp/context', {
+    run: function (context, callback) {
+        return callback();
+    }
+});
+
+assert.mock('/lib/xp/project', {
+    list: function () {
+        return [
+            {
+                id: 'myproject',
+                displayName: 'My Project'
+            }
+        ];
+    }
+});
+
+assert.mock('/lib/xp/content', {
+    get: function (params) {
+        return {
+            _id: params.key,
+            _name: 'my-content',
+            displayName: 'My Content'
+        };
+    }
+});
+
+var layersApi = require('/apis/layers/layers');
+
+exports.testGetReturnsCompareAndPublishStatus = function () {
+    var result = layersApi.get({
+        params: {
+            contentId: 'abc',
+            project: 'myproject'
+        }
+    });
+
+    assert.assertEquals(200, result.status);
+
+    var projects = result.body.projects;
+    assert.assertEquals(1, projects.length);
+
+    var entry = projects[0];
+    assert.assertEquals('myproject', entry.project.id);
+    assert.assertEquals('abc', entry.item._id);
+    assert.assertEquals('NEW', entry.compareAndPublishStatus.compareStatus);
+    assert.assertEquals('ONLINE', entry.compareAndPublishStatus.publishStatus);
+};
+
+exports.testGetMissingParamsReturnsBadRequest = function () {
+    var result = layersApi.get({
+        params: {}
+    });
+
+    assert.assertEquals(400, result.status);
+};


### PR DESCRIPTION
The layers API set `contentId` on `CompareStatusHandler` Nashorn-style (`bean.contentId = x`). GraalJS does not map a property write on a Java host object to its setter, and `CompareStatusHandler` exposes only a setter — no public field — so the write failed at runtime:

```
TypeError: writeMember (contentId) on com.enonic.xp.app.contentstudio.plus.widgets.layers.CompareStatusHandler failed due to: Unknown identifier: contentId
```

The write now calls `setContentId(...)`, with the value passed through `__.nullOrValue(...)` so a `String` setter receives `null` rather than `undefined`. Reference: enonic/lib-sql#154.

### Tested on both engines

This repository had no JS-executing tests, so nothing reached the affected site on either engine. Added `LayersApiTest` (`/test/layers-test.js`), which exercises `apis/layers/layers.js` `get` and asserts the returned compare/publish status. The suite runs once per engine — Nashorn via `test`, GraalJS via a new `testGraalJs` task — both wired into `check`, mirroring `gradle/js-tests.gradle` in the platform.

```
test         2 tests, 0 failed
testGraalJs  2 tests, 0 failed   (against a local build of enonic/xp#12198)
```

Before the fix, `testGraalJs` failed on `testGetReturnsCompareAndPublishStatus` with the `TypeError` above while `test` stayed green — the divergence the second engine exists to catch.

### CI note

`testGraalJs` needs the `ScriptRunnerSupport` fix from enonic/xp#12198, which keeps the script executor alive through JS test discovery. **CI `testGraalJs` will stay red until that PR is merged and a fresh `8.1.0-SNAPSHOT` is published** — the snapshot currently on `repo.enonic.com/dev` still carries the old `ScriptRunnerSupport`, which closes the executor during test discovery and fails every GraalJS test with `The Context is already closed`. Holding this as a draft until then; verified green locally against a `publishToMavenLocal` build of that branch.

Fixes #1869

<sub>*Drafted with AI assistance*</sub>