### PR TITLE
Add missing react-resizable-panels dependency #1879

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "neverthrow": "^8.2.0",
     "preact": "^10.29.7",
     "q": "^1.5.1",
+    "react-resizable-panels": "4.12.0",
     "react-virtuoso": "^4.18.11"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       q:
         specifier: ^1.5.1
         version: 1.5.1
+      react-resizable-panels:
+        specifier: 4.12.0
+        version: 4.12.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react-virtuoso:
         specifier: ^4.18.11
         version: 4.18.11(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -2063,6 +2066,12 @@ packages:
     peerDependencies:
       react: ^19.2.5
 
+  react-resizable-panels@4.12.0:
+    resolution: {integrity: sha512-t/Gp57qSCxGQ52ckhz+8lM7dnuymeU95TEzl2U203qEbGkSLHrtm7US2/ANzq/zOlja3CwPTAfCDuh1unv9mfw==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
   react-virtuoso@4.18.11:
     resolution: {integrity: sha512-Qeeq9vqa5seCxACvzbQTUeq3s2/Bu+VlwOMF0jfy3E/ZKHLiXWwJpXBhv2rckqYkvm1XRVFLCBMCmqCU8JNEJg==}
     peerDependencies:
@@ -3895,6 +3904,11 @@ snapshots:
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
+
+  react-resizable-panels@4.12.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   react-virtuoso@4.18.11(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:


### PR DESCRIPTION
Declared `react-resizable-panels` 4.12.0 in dependencies, matching the version pinned by `@enonic/lib-contentstudio`. Fixed the unresolved import of `react-resizable-panels` in `build:prod:js` and the `check:devdeps` failure.