### PR TITLE
Version History widget fails in Archive view #1878

### DIFF
--- a/src/main/resources/assets/js/archive.ts
+++ b/src/main/resources/assets/js/archive.ts
@@ -2,7 +2,8 @@ import {Body} from '@enonic/lib-admin-ui/dom/Body';
 import type {Element} from '@enonic/lib-admin-ui/dom/Element';
 import {initConfig} from '@enonic/lib-contentstudio/v6/shared/config/config.store';
 import {whenProjectInitialized} from '@enonic/lib-contentstudio/v6/entities/project/activeProject.store';
-import {initProjects} from '@enonic/lib-contentstudio/v6/entities/project/projects.store';
+import {$projects, initProjects} from '@enonic/lib-contentstudio/v6/entities/project/projects.store';
+import {setActiveProjectResolver} from '@enonic/lib-contentstudio/v6/shared/lib/url/cms';
 import {getModuleScript, getRequiredAttribute} from './util/ModuleScriptHelper';
 
 // ! Import the app container lazily so v6 config is initialized (initConfig below)
@@ -22,6 +23,7 @@ void (() => {
     const body: Body = Body.get();
     const widgetEl: Element = body.findChildById(elemId, true);
     initConfig(getRequiredAttribute(currentScript, 'data-config-script-id'));
+    setActiveProjectResolver(() => $projects.get().activeProjectId);
     initProjects();
 
     const renderListener = (): void => {

--- a/src/main/resources/assets/js/extension/layers/main.ts
+++ b/src/main/resources/assets/js/extension/layers/main.ts
@@ -7,7 +7,8 @@ import {resolveConfig} from '../../util/WidgetConfigResolver';
 import {getModuleScript, getRequiredAttribute, getOptionalAttribute} from '../../util/ModuleScriptHelper';
 import {Messages} from '@enonic/lib-admin-ui/util/Messages';
 import {whenProjectInitialized} from '@enonic/lib-contentstudio/v6/entities/project/activeProject.store';
-import {initProjects} from '@enonic/lib-contentstudio/v6/entities/project/projects.store';
+import {$projects, initProjects} from '@enonic/lib-contentstudio/v6/entities/project/projects.store';
+import {setActiveProjectResolver} from '@enonic/lib-contentstudio/v6/shared/lib/url/cms';
 
 void (() => {
     const currentScript = getModuleScript('layers');
@@ -19,6 +20,7 @@ void (() => {
     CONFIG.setConfig(resolveConfig(configScriptId));
     initConfig(configScriptId);
     Messages.addMessages(JSON.parse(CONFIG.getString('phrasesAsJson')) as object);
+    setActiveProjectResolver(() => $projects.get().activeProjectId);
     initProjects(projectName);
 
     const extensionContainer = Element.fromHtmlElement(

--- a/src/main/resources/assets/js/extension/publish-report/main.ts
+++ b/src/main/resources/assets/js/extension/publish-report/main.ts
@@ -7,7 +7,8 @@ import {resolveConfig} from '../../util/WidgetConfigResolver';
 import {getModuleScript, getRequiredAttribute, getOptionalAttribute} from '../../util/ModuleScriptHelper';
 import {Messages} from '@enonic/lib-admin-ui/util/Messages';
 import {whenProjectInitialized} from '@enonic/lib-contentstudio/v6/entities/project/activeProject.store';
-import {initProjects} from '@enonic/lib-contentstudio/v6/entities/project/projects.store';
+import {$projects, initProjects} from '@enonic/lib-contentstudio/v6/entities/project/projects.store';
+import {setActiveProjectResolver} from '@enonic/lib-contentstudio/v6/shared/lib/url/cms';
 
 void (() => {
     const currentScript = getModuleScript('publish-report');
@@ -22,6 +23,7 @@ void (() => {
     CONFIG.setConfig(resolveConfig(configScriptId));
     initConfig(configScriptId);
     Messages.addMessages(JSON.parse(CONFIG.getString('phrasesAsJson')) as object);
+    setActiveProjectResolver(() => $projects.get().activeProjectId);
     initProjects(projectName);
 
     const extensionContainer = Element.fromHtmlElement(

--- a/src/main/resources/assets/js/extension/variants/main.ts
+++ b/src/main/resources/assets/js/extension/variants/main.ts
@@ -7,7 +7,8 @@ import {resolveConfig} from '../../util/WidgetConfigResolver';
 import {getModuleScript, getRequiredAttribute, getOptionalAttribute} from '../../util/ModuleScriptHelper';
 import {Messages} from '@enonic/lib-admin-ui/util/Messages';
 import {whenProjectInitialized} from '@enonic/lib-contentstudio/v6/entities/project/activeProject.store';
-import {initProjects} from '@enonic/lib-contentstudio/v6/entities/project/projects.store';
+import {$projects, initProjects} from '@enonic/lib-contentstudio/v6/entities/project/projects.store';
+import {setActiveProjectResolver} from '@enonic/lib-contentstudio/v6/shared/lib/url/cms';
 
 void (() => {
     const currentScript = getModuleScript('variants');
@@ -19,6 +20,7 @@ void (() => {
     CONFIG.setConfig(resolveConfig(configScriptId));
     initConfig(configScriptId);
     Messages.addMessages(JSON.parse(CONFIG.getString('phrasesAsJson')) as object);
+    setActiveProjectResolver(() => $projects.get().activeProjectId);
     initProjects(projectName);
 
     const extensionContainer = Element.fromHtmlElement(


### PR DESCRIPTION
Wired `setActiveProjectResolver` in the archive entry point, so `getCmsApiUrl` no longer builds `getVersions` requests with an empty project segment Wired the same resolver in the `layers`, `variants` and `publish-report` entry points, since each widget bundle owns its own copy of the resolver