### PR TITLE
Layers widget reports no project access for content removed in a laye…

### DIFF
--- a/src/main/resources/assets/js/v6/features/views/context/widget/layers/LayerCard.tsx
+++ b/src/main/resources/assets/js/v6/features/views/context/widget/layers/LayerCard.tsx
@@ -41,6 +41,7 @@ export const LayerCard = ({item, isCurrent, isInChain, level, isExpanded, onTogg
     const isRoot = level === 0;
     const project = item.getProject();
     const hasItem = item.hasItem();
+    const hasProjectAccess = !!project.getDisplayName();
     const content = hasItem ? item.getItem() : null;
     const fieldsetRef = useRef<HTMLFieldSetElement>(null);
     const buttonRef = useRef<HTMLButtonElement>(null);
@@ -175,7 +176,7 @@ export const LayerCard = ({item, isCurrent, isInChain, level, isExpanded, onTogg
 
                 {!hasItem && (
                     <div className="mt-2 text-center text-xs italic text-subtle">
-                        {i18n('dialog.layers.notAvailable')}
+                        {i18n(hasProjectAccess ? 'text.content.not.found' : 'dialog.layers.notAvailable')}
                     </div>
                 )}
             </fieldset>


### PR DESCRIPTION
…r #1906

Branched the empty-card placeholder on `project.getDisplayName()`, which is exactly the server's `isAvailableProject` check Kept `dialog.layers.notAvailable` for stub projects built by `createReadonlyProject`, where the user really has no access Used the existing `text.content.not.found` phrase when the project is readable but the content is not in that layer